### PR TITLE
Only invoke deploy:upload once in create_release task, not once per host

### DIFF
--- a/lib/capistrano/scm/none.rb
+++ b/lib/capistrano/scm/none.rb
@@ -12,13 +12,10 @@ module Capistrano
           namespace :scm do
             namespace :none do
               task :create_release do
-                on release_roles :all do
-                  execute :mkdir, "-p", release_path
-                  if Rake::Task.task_defined?('deploy:upload')
-                    invoke('deploy:upload')
-                  else
-                    raise "Expecting a deploy:upload task to be defined."
-                  end
+                if Rake::Task.task_defined?('deploy:upload')
+                  invoke('deploy:upload')
+                else
+                  raise "Expecting a deploy:upload task to be defined."
                 end
               end
 

--- a/lib/capistrano/scm/none.rb
+++ b/lib/capistrano/scm/none.rb
@@ -12,6 +12,9 @@ module Capistrano
           namespace :scm do
             namespace :none do
               task :create_release do
+                on release_roles :all do
+                  execute :mkdir, "-p", release_path
+                end
                 if Rake::Task.task_defined?('deploy:upload')
                   invoke('deploy:upload')
                 else


### PR DESCRIPTION
Calling invoke within an 'on' block causes a multiple invocation error. This just invokes it once and relies on the implementor to handle the hosts/on block in their code. 